### PR TITLE
Add missing url parameter to compile call

### DIFF
--- a/src/index.ls
+++ b/src/index.ls
@@ -19,7 +19,7 @@ module.exports = (opts = {})->
         delete opts.parsers
 
       try
-        compiled-code = compile file.contents.to-string!, opts
+        compiled-code = compile file.contents.to-string!, opts, file.path
       catch err
         return callback new gutil.PluginError \gulp-riot, "#{file.path}: Compiler Error: #{err}"
 


### PR DESCRIPTION
Related riot issue: https://github.com/riot/riot/issues/467
