### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This plugin compile [riot](https://github.com/muut/riotjs)'s `.tag` files.
 </example>
 ```
 
-`gulpfile.js`:
+`gulpfile.babel.js`:
 
 ```js
 import gulp from 'gulp';


### PR DESCRIPTION
The gulpfile is written in ES6 style but babel is not referenced in the README.

Update the file name to avoid confusion.
