### PR TITLE
Update Riot.js dependency for more flexible state

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp-util": "3.0.8",
-    "riot": "3.3.1",
+    "riot": "3.x",
     "through2": "2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
As we can find in [semver docs](https://docs.npmjs.com/misc/semver#x-ranges-12x-1x-12-), we can set Riot.js dependency as `3.x` to this library will can work with any 3.x Riot.js version.